### PR TITLE
SelfTasks.register implemented

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <name>Self XDSD Storage Module</name>
     <description>Storage Module for Self XDSD</description>
     <properties>
-        <self.core.version>0.0.4</self.core.version>
+        <self.core.version>0.0.5</self.core.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <build>

--- a/src/main/java/com/selfxdsd/storage/SelfTasks.java
+++ b/src/main/java/com/selfxdsd/storage/SelfTasks.java
@@ -51,9 +51,9 @@ import static com.selfxdsd.storage.generated.jooq.tables.SlfUsersXdsd.SLF_USERS_
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 0.0.1
- * @todo #41:30min Continue implementing and writing integration tests
- *  for the methods of SelfTasks. Methods getById, ofProject and ofContributor
- *  are already implemented.
+ * @todo #48:30min Continue implementing and writing integration tests
+ *  for the methods of SelfTasks. Methods getById, register ofProject
+ *  and ofContributor are already implemented.
  */
 public final class SelfTasks implements Tasks {
 

--- a/src/main/java/com/selfxdsd/storage/SelfTasks.java
+++ b/src/main/java/com/selfxdsd/storage/SelfTasks.java
@@ -185,6 +185,11 @@ public final class SelfTasks implements Tasks {
     }
 
     @Override
+    public Tasks unassigned() {
+        throw new UnsupportedOperationException("Not yet implemented.");
+    }
+
+    @Override
     public Iterator<Task> iterator() {
         throw new UnsupportedOperationException("Not yet implemented.");
     }


### PR DESCRIPTION
PR for #48 

* Implemented and tested SelfTasks.registered
* Fixed bug in Task SELECT: we need LEFT JOIN for Contracts/Contributor, otherwise unassigned Tasks (where username == null) will not be selected.