### PR TITLE
 #59 SelfContributors.ofProject implemented and tested

### DIFF
--- a/src/main/java/com/selfxdsd/storage/SelfContributors.java
+++ b/src/main/java/com/selfxdsd/storage/SelfContributors.java
@@ -25,7 +25,9 @@ package com.selfxdsd.storage;
 import com.selfxdsd.api.Contributor;
 import com.selfxdsd.api.Contributors;
 import com.selfxdsd.api.storage.Storage;
+import com.selfxdsd.core.contracts.StoredContract;
 import com.selfxdsd.core.contributors.StoredContributor;
+import com.selfxdsd.core.projects.StoredProject;
 import org.jooq.Record;
 import org.jooq.Result;
 
@@ -33,6 +35,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
+import static com.selfxdsd.storage.generated.jooq.Tables.SLF_CONTRACTS_XDSD;
 import static com.selfxdsd.storage.generated.jooq.Tables.SLF_CONTRIBUTORS_XDSD;
 
 /**
@@ -112,6 +115,24 @@ public final class SelfContributors implements Contributors {
         final String repoFullName,
         final String repoProvider
     ) {
+        final Result<Record> result = this.database.jooq()
+            .select()
+            .from(SLF_CONTRIBUTORS_XDSD)
+            .join(SLF_CONTRACTS_XDSD)
+            .on(
+                SLF_CONTRACTS_XDSD.USERNAME.eq(SLF_CONTRIBUTORS_XDSD.USERNAME)
+                    .and(
+                        SLF_CONTRACTS_XDSD.PROVIDER.eq(
+                            SLF_CONTRIBUTORS_XDSD.PROVIDER
+                        )
+                    )
+            )
+            .where(
+                SLF_CONTRACTS_XDSD.REPO_FULLNAME.eq(repoFullName).and(
+                    SLF_CONTRACTS_XDSD.PROVIDER.eq(repoProvider)
+                )
+            )
+            .fetch();
         throw new UnsupportedOperationException("Not yet implemented.");
     }
 

--- a/src/main/java/com/selfxdsd/storage/SelfContributors.java
+++ b/src/main/java/com/selfxdsd/storage/SelfContributors.java
@@ -23,7 +23,6 @@
 package com.selfxdsd.storage;
 
 import com.selfxdsd.api.Contract;
-import com.selfxdsd.api.Contracts;
 import com.selfxdsd.api.Contributor;
 import com.selfxdsd.api.Contributors;
 import com.selfxdsd.api.storage.Storage;
@@ -31,7 +30,6 @@ import com.selfxdsd.core.contracts.ContributorContracts;
 import com.selfxdsd.core.contracts.StoredContract;
 import com.selfxdsd.core.contributors.ProjectContributors;
 import com.selfxdsd.core.contributors.StoredContributor;
-import com.selfxdsd.core.projects.StoredProject;
 import org.jooq.Record;
 import org.jooq.Result;
 

--- a/src/main/java/com/selfxdsd/storage/SelfProjects.java
+++ b/src/main/java/com/selfxdsd/storage/SelfProjects.java
@@ -37,7 +37,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static com.selfxdsd.storage.generated.jooq.Tables.SLF_CONTRACTS_XDSD;
 import static com.selfxdsd.storage.generated.jooq.tables.SlfPmsXdsd.SLF_PMS_XDSD;
 import static com.selfxdsd.storage.generated.jooq.tables.SlfProjectsXdsd.SLF_PROJECTS_XDSD;
 import static com.selfxdsd.storage.generated.jooq.tables.SlfUsersXdsd.SLF_USERS_XDSD;
@@ -202,7 +201,7 @@ public final class SelfProjects implements Projects {
     @Override
     public Iterator<Project> iterator() {
         final int maxRecords = this.database.jooq()
-            .fetchCount(SLF_CONTRACTS_XDSD);
+            .fetchCount(SLF_PROJECTS_XDSD);
         return PagedIterator.create(
             100,
             maxRecords,

--- a/src/test/resources/insertTestData.sql
+++ b/src/test/resources/insertTestData.sql
@@ -60,6 +60,14 @@ INSERT INTO self_xdsd.slf_contracts_xdsd
 (repo_fullname, username, provider, role, hourly_rate)
 VALUES ('amihaiemil/docker-java-api', 'maria', 'github', 'REV', 8000);
 
+INSERT INTO self_xdsd.slf_contracts_xdsd
+(repo_fullname, username, provider, role, hourly_rate)
+VALUES ('vlad/test', 'maria', 'github', 'DEV', 16000);
+
+INSERT INTO self_xdsd.slf_contracts_xdsd
+(repo_fullname, username, provider, role, hourly_rate)
+VALUES ('vlad/test', 'maria', 'github', 'REV', 8000);
+
 -- INSERT TASKS
 INSERT INTO self_xdsd.slf_tasks_xdsd
 (repo_fullname, issueId, provider, role)


### PR DESCRIPTION
Fixes #59 

Implemented SelfContributors.ofProject. Each Contributor's Contracts are also loaded eagerly because, most of the times when we are dealing with a Project's contributors, we are interested in their contracts.