### PR TITLE
#140. Support for onDuplicateKeyIgnored() in SelfContracts

### DIFF
--- a/src/main/java/com/selfxdsd/storage/Database.java
+++ b/src/main/java/com/selfxdsd/storage/Database.java
@@ -51,4 +51,31 @@ public interface Database extends Closeable {
      */
     void close();
 
+
+    /**
+     * Underneath database driver. Could be MySql, H2 etc.
+     * @return Engine.
+     */
+    String dbms();
+
+    /**
+     * Underneath database driver. Could be MySql, H2 etc.
+     */
+    final class Dbms {
+        /**
+         * MySql.
+         */
+        public static final String MY_SQL = "MY_SQL";
+        /**
+         * H2.
+         */
+        public static final String H2 = "H2";
+
+        /**
+         * Private constructor.
+         */
+        private Dbms() {
+            throw new IllegalStateException("Not allowed to construct");
+        }
+    }
 }

--- a/src/main/java/com/selfxdsd/storage/MySql.java
+++ b/src/main/java/com/selfxdsd/storage/MySql.java
@@ -136,4 +136,9 @@ public final class MySql implements Database {
             }
         }
     }
+
+    @Override
+    public String dbms() {
+        return Dbms.MY_SQL;
+    }
 }

--- a/src/test/java/com/selfxdsd/storage/H2Database.java
+++ b/src/test/java/com/selfxdsd/storage/H2Database.java
@@ -133,4 +133,9 @@ public final class H2Database implements Database {
             }
         }
     }
+
+    @Override
+    public String dbms() {
+        return Dbms.H2;
+    }
 }


### PR DESCRIPTION
- onDuplicateKeyIgnored() is not supported by H2, thus added a way to figure out on what db jooq operates (MySql, H2): Database#dbms()

PR for #140 