### PR TITLE
#196 Remove and Invoice Task in Transaction

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <name>Self XDSD Storage Module</name>
     <description>Storage Module for Self XDSD</description>
     <properties>
-        <self.core.version>0.0.42</self.core.version>
+        <self.core.version>0.0.43</self.core.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <build>

--- a/src/test/resources/insertTestData.sql
+++ b/src/test/resources/insertTestData.sql
@@ -139,6 +139,11 @@ INSERT INTO self_xdsd.slf_tasks_xdsd
 VALUES
 ('amihaiemil/docker-java-api', '125', 'github', 'DEV', 'alexandra', '2020-06-14', '2020-06-24', 60);
 
+INSERT INTO self_xdsd.slf_tasks_xdsd
+(repo_fullname, issueId, provider, role, username, assigned, deadline, estimation_minutes)
+VALUES
+('amihaiemil/docker-java-api', '126', 'github', 'DEV', 'alexandra', '2020-12-14', '2020-12-24', 60);
+
 
 INSERT INTO self_xdsd.slf_tasks_xdsd
 (repo_fullname, issueId, provider, role, username, assigned, deadline, estimation_minutes)


### PR DESCRIPTION
Fixes #196 

Removing a Task and adding to the Invoice, in the same transaction.
Modified the SelfInvoicedTasksITCase.registerTask() to work with real data instead of mocks and also made assertions on the removed tasks.