### PR TITLE
#217 SelfInvoices.registerAsPaid creates PlatformInvoice

### DIFF
--- a/src/test/java/com/selfxdsd/storage/SelfPlatformInvoicesITCase.java
+++ b/src/test/java/com/selfxdsd/storage/SelfPlatformInvoicesITCase.java
@@ -215,7 +215,9 @@ public final class SelfPlatformInvoicesITCase {
         ).platformInvoices();
         MatcherAssert.assertThat(
             invoices,
-            Matchers.iterableWithSize(2)
+            Matchers.iterableWithSize(
+                Matchers.greaterThanOrEqualTo(2)
+            )
         );
         final Iterator<PlatformInvoice> iterator = invoices.iterator();
         final PlatformInvoice first = iterator.next();


### PR DESCRIPTION
PR for #217 

If the Invoice is paid with a real wallet (``transactionId`` does NOT start with ``fake_payment_```), then method SelfInvoices.registerAsPaid will also insert a new PlatformInvoice in the DB.
Updated tests.