### PR TITLE
#239 self-core 62 and puzzles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <name>Self XDSD Storage Module</name>
     <description>Storage Module for Self XDSD</description>
     <properties>
-        <self.core.version>0.0.61</self.core.version>
+        <self.core.version>0.0.62</self.core.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <build>

--- a/src/main/java/com/selfxdsd/storage/SelfApiTokens.java
+++ b/src/main/java/com/selfxdsd/storage/SelfApiTokens.java
@@ -31,6 +31,7 @@ import com.selfxdsd.core.StoredUser;
 import org.jooq.Record;
 import org.jooq.Result;
 
+import java.time.LocalDateTime;
 import java.util.Iterator;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
@@ -43,6 +44,10 @@ import static com.selfxdsd.storage.generated.jooq.tables.SlfUsersXdsd.SLF_USERS_
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 0.0.27
+ * @todo #239:60min Implement and test method register(...) here, which should
+ *  insert and return the newly registered ApiToken.
+ * @todo #239:60min Implement and test method remove(...) here, which should
+ *  remove the specified ApiToken from the DB.
  */
 public final class SelfApiTokens implements ApiTokens {
 
@@ -147,10 +152,46 @@ public final class SelfApiTokens implements ApiTokens {
             }
 
             @Override
+            public boolean remove(final ApiToken token) {
+                throw new UnsupportedOperationException(
+                    "ApiTokens of a User are immutable, you cannot remove "
+                    + "one here."
+                );
+            }
+
+            @Override
+            public ApiToken register(
+                final String name,
+                final String token,
+                final LocalDateTime expiration,
+                final User user
+            ) {
+                throw new UnsupportedOperationException(
+                    "ApiTokens of a User are immutable, you cannot register "
+                    + "one here."
+                );
+            }
+
+            @Override
             public Iterator<ApiToken> iterator() {
                 return this.apiTokens.get().iterator();
             }
         };
+    }
+
+    @Override
+    public boolean remove(final ApiToken apiToken) {
+        throw new UnsupportedOperationException("Not yet implemented.");
+    }
+
+    @Override
+    public ApiToken register(
+        final String name,
+        final String token,
+        final LocalDateTime expiration,
+        final User user
+    ){
+        throw new UnsupportedOperationException("Not yet implemented.");
     }
 
     @Override

--- a/src/main/java/com/selfxdsd/storage/SelfUsers.java
+++ b/src/main/java/com/selfxdsd/storage/SelfUsers.java
@@ -29,6 +29,7 @@ import org.jooq.DSLContext;
 import org.jooq.Record;
 import org.jooq.Result;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -193,6 +194,12 @@ public final class SelfUsers implements Users {
                 @Override
                 public ApiTokens apiTokens() {
                     return found.apiTokens();
+                }
+
+                @Override
+                public ApiToken register(final String name, final  String token,
+                                         final LocalDateTime expiration) {
+                    return found.register(name, token, expiration);
                 }
             };
         }


### PR DESCRIPTION
Fixes #239 

Updated to self-core 0.0.62;
Left puzzles to implement and test methods SelfApiTokens.register(...) and SelfApiTokens.remove(...);